### PR TITLE
new-people-simple-network-sim

### DIFF
--- a/.github/workflows/issue-label-notifications.yml
+++ b/.github/workflows/issue-label-notifications.yml
@@ -19,6 +19,6 @@ jobs:
                Covid19_EERAModel=@thibaud-porphyre @peter-t-fox
                Data management=@IainM-BioSS @aaron-reeves
                model reconstruction=@kzscisoft @richardreeve
-               Simple Network Sim=@magicicada @bobturneruk @aflag
+               Simple Network Sim=@magicicada @bobturneruk @aflag @nathan-cummings-ukaea @WPettersson @alex-konovalov
                Simulation.jl=@claireh93 @richardreeve @jwscook @sdl1 @wytbella
                interoperability=@alysbrett @richardreeve


### PR DESCRIPTION
Adds notifications for new simple network sim team members. Don't know whether I'm supposed to edit `master` directly in this case. Feels wrong! So I did a PR.